### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,31 +6,31 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Tlc5940Mux      KEYWORD1
+Tlc5940Mux	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init            KEYWORD2
-clear           KEYWORD2
-set             KEYWORD2
-setAll          KEYWORD2
-setRow          KEYWORD2
-get             KEYWORD2
-setAllDC        KEYWORD2
-readXERR        KEYWORD2
+init	KEYWORD2
+clear	KEYWORD2
+set	KEYWORD2
+setAll	KEYWORD2
+setRow	KEYWORD2
+get	KEYWORD2
+setAllDC	KEYWORD2
+readXERR	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
 
-TlcMux          KEYWORD2
+TlcMux	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-NUM_TLCS        LITERAL1
-TLC_NUM_MUX     LITERAL1
-tlcMux_GSData   LITERAL1
+NUM_TLCS	LITERAL1
+TLC_NUM_MUX	LITERAL1
+tlcMux_GSData	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords